### PR TITLE
[14.0][FIX] base_report_to_printer: Close dialog on direct print.

### DIFF
--- a/base_report_to_printer/static/src/js/qweb_action_manager.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.js
@@ -31,6 +31,17 @@ odoo.define("base_report_to_printer.print", function (require) {
                                         print_action.printer_name
                                     )
                                 );
+                                if (action.close_on_report_download) {
+                                    var closeAction = {
+                                        type: "ir.actions.act_window_close",
+                                    };
+                                    self.doAction(
+                                        closeAction,
+                                        _.pick(options, "on_close")
+                                    );
+                                } else {
+                                    options.on_close();
+                                }
                             },
                             function () {
                                 self.do_notify(
@@ -43,6 +54,17 @@ odoo.define("base_report_to_printer.print", function (require) {
                                         print_action.printer_name
                                     )
                                 );
+                                if (action.close_on_report_download) {
+                                    var closeAction = {
+                                        type: "ir.actions.act_window_close",
+                                    };
+                                    self.doAction(
+                                        closeAction,
+                                        _.pick(options, "on_close")
+                                    );
+                                } else {
+                                    options.on_close();
+                                }
                             }
                         );
                     } else {


### PR DESCRIPTION
Ensure wizard is closed if direct print is initiated from a wizard button.

The _triggerDownload function on base Odoo ActionManager explicitly closes any open wizard dialogs in the UI.

This commit adds the same code to _triggerDownload for server print.

Without this code if a server print is initiated from a wizard button the wizard dialog remains open in the UI, even though the print has completed successfully.